### PR TITLE
Refactor Path Handling

### DIFF
--- a/lib/fryse.ex
+++ b/lib/fryse.ex
@@ -9,7 +9,9 @@ defmodule Fryse do
 
   defstruct config: nil,
             data: nil,
-            content: nil
+            content: nil,
+            source_path: nil,
+            destination_path: nil
 
   def index(path) do
     Indexer.index(path)

--- a/lib/fryse/builder.ex
+++ b/lib/fryse/builder.ex
@@ -5,35 +5,40 @@ defmodule Fryse.Builder do
   alias Fryse.Page
   alias Fryse.FilePath
 
-  def build(%Fryse{config: config} = fryse) do
-    with :ok <- clean(),
-         :ok <- setup(),
-         :ok <- copy_theme_assets(config),
-         :ok <- copy_custom_files(config),
+  def build(%Fryse{} = fryse) do
+    with :ok <- clean(fryse),
+         :ok <- setup(fryse),
+         :ok <- copy_theme_assets(fryse),
+         :ok <- copy_custom_files(fryse),
          results <- build_content(fryse) do
       {:ok, results}
     end
   end
 
-  defp clean() do
-    case File.rm_rf("_site") do
+  defp clean(%Fryse{destination_path: dp}) do
+    case File.rm_rf(dp) do
       {:ok, _} -> :ok
       {:error, reason, _} -> {:error, reason}
     end
   end
 
-  defp setup(), do: File.mkdir("_site")
+  defp setup(%Fryse{destination_path: dp}), do: File.mkdir_p(dp)
 
-  defp copy_theme_assets(%{theme: theme}) do
-    case File.cp_r("./themes/#{theme}/assets/", "_site/assets/") do
+  defp copy_theme_assets(%Fryse{config: %{theme: theme}, source_path: sp, destination_path: dp}) do
+    assets_source = Path.join(sp, "themes/#{theme}/assets/")
+    assets_destination = Path.join(dp, "assets/")
+
+    case File.cp_r(assets_source, assets_destination) do
       {:ok, _} -> :ok
       {:error, reason, _} -> {:error, reason}
     end
   end
 
-  defp copy_custom_files(%{files: files}) when is_list(files) do
+  defp copy_custom_files(%Fryse{config: %{files: files}, source_path: sp, destination_path: dp}) when is_list(files) do
     for %{from: from, to: to} <- files do
-      File.cp_r(from, "_site/#{to}")
+      from_path = Path.join(sp, from)
+      to_path = Path.join(dp, to)
+      File.cp_r(from_path, to_path)
     end
 
     # TODO: filter through comprehension return value and look for errors
@@ -42,8 +47,8 @@ defmodule Fryse.Builder do
 
   defp copy_custom_files(_), do: :ok
 
-  defp build_content(%Fryse{config: config, content: content} = fryse) do
-    build_folder(content, fryse, "_site/")
+  defp build_content(%Fryse{content: content, destination_path: dp} = fryse) do
+    build_folder(content, fryse, dp)
     |> List.flatten()
     |> sort_by_status()
   end
@@ -56,7 +61,7 @@ defmodule Fryse.Builder do
   end
 
   defp build_folder(%Fryse.Folder{children: children}, fryse, path) do
-    File.mkdir(path)
+    File.mkdir_p(path)
 
     for entry <- children do
       case entry do
@@ -71,8 +76,8 @@ defmodule Fryse.Builder do
 
   defp render_file(%Fryse.File{excluded: true} = file, _), do: {:excluded, {:file, file.path}}
 
-  defp render_file(file, fryse) do
-    destination = FilePath.source_to_destination(fryse.config, file.path)
+  defp render_file(file, %Fryse{destination_path: dp} = fryse) do
+    destination = Path.join(dp, FilePath.source_to_destination(fryse.config, file.path))
 
     page = %Page{
       fryse: fryse,

--- a/lib/fryse/cli/build.ex
+++ b/lib/fryse/cli/build.ex
@@ -48,6 +48,7 @@ defmodule Fryse.CLI.Build do
   defp show_error_results(_), do: nil
 
   defp show_file_error({:file, source, _destination, error}) do
+    #TODO: no case clause matching: %UndefinedFunctionError{arity: 2, exports: nil, function: :author, module: FriseDefaultTheme, reason: nil}
     error_description =
       case error do
         %{description: description, file: "nofile", line: line} ->
@@ -57,8 +58,7 @@ defmodule Fryse.CLI.Build do
           "#{description} in #{file} on line #{line}"
 
         %{message: message, file: "nofile", line: line} ->
-          # for some reason, it contains the proper line number
-          "#{message} in #{source} on line #{line}"
+          "#{message} in #{source} on line #{line} (line counting starts below the frontmatter section)"
 
         %{message: message, file: file, line: line} ->
           "#{message} in #{file} on line #{line}"

--- a/lib/fryse/file_path.ex
+++ b/lib/fryse/file_path.ex
@@ -1,7 +1,7 @@
 defmodule Fryse.FilePath do
   @moduledoc false
 
-  def source_to_destination(config, "./content" <> path), do: source_to_destination(config, path)
+  def source_to_destination(config, "content" <> path), do: source_to_destination(config, path)
 
   def source_to_destination(_config, path) do
     name =
@@ -14,18 +14,23 @@ defmodule Fryse.FilePath do
       path
       |> Path.split()
       |> Enum.drop(-1)
-      |> Path.join()
+
+
+    path = case path do
+      [] -> ""
+      _ -> Path.join(path)
+    end
 
     path =
       case path do
-        "/" -> Path.join([".", "_site"])
-        _ -> Path.join([".", "_site", path])
+        "/" <> rest -> rest
+        _ -> path
       end
 
     Path.join(path, [name, ".html"])
   end
 
-  def source_to_url(config, "./content" <> path), do: source_to_url(config, path)
+  def source_to_url(config, "content" <> path), do: source_to_url(config, path)
 
   def source_to_url(_config, path) do
     path = Path.join("/", path)

--- a/lib/fryse/script_loader.ex
+++ b/lib/fryse/script_loader.ex
@@ -1,9 +1,9 @@
 defmodule Fryse.ScriptLoader do
   @moduledoc false
 
-  def load_for(%Fryse{config: %{theme: theme}}) do
-    project_scripts = project_scripts()
-    theme_scripts = theme_scripts(theme)
+  def load_for(%Fryse{config: %{theme: theme}, source_path: source_path}) do
+    project_scripts = project_scripts(source_path)
+    theme_scripts = theme_scripts(source_path, theme)
 
     files = project_scripts ++ theme_scripts
 
@@ -13,11 +13,11 @@ defmodule Fryse.ScriptLoader do
     end
   end
 
-  defp project_scripts() do
-    Path.wildcard("./scripts/**/*.{ex,exs}")
+  defp project_scripts(source_path) do
+    Path.wildcard(Path.join(source_path, "scripts/**/*.{ex,exs}"))
   end
 
-  defp theme_scripts(theme) do
-    Path.wildcard("./themes/#{theme}/scripts/**/*.{ex,exs}")
+  defp theme_scripts(source_path, theme) do
+    Path.wildcard(Path.join(source_path, "themes/#{theme}/scripts/**/*.{ex,exs}"))
   end
 end

--- a/test/fryse/file_path_test.exs
+++ b/test/fryse/file_path_test.exs
@@ -3,20 +3,21 @@ defmodule Fryse.FilePathTest do
   alias Fryse.FilePath
 
   test "source_to_destination/2 generates the correct destination path" do
-    assert "./_site/index.html" = FilePath.source_to_destination({}, "./content/index.md")
-    assert "./_site/index.html" = FilePath.source_to_destination({}, "/index.md")
+    assert "index.html" = FilePath.source_to_destination({}, "content/index.md")
+    assert "index.html" = FilePath.source_to_destination({}, "/index.md")
+    assert "index.html" = FilePath.source_to_destination({}, "index.md")
 
-    assert "./_site/posts/test.html" =
-             FilePath.source_to_destination({}, "./content/posts/test.md")
+    assert "posts/test.html" =
+             FilePath.source_to_destination({}, "content/posts/test.md")
 
-    assert "./_site/posts/test.html" = FilePath.source_to_destination({}, "/posts/test.md")
+    assert "posts/test.html" = FilePath.source_to_destination({}, "/posts/test.md")
   end
 
   test "source_to_url/2 generates the correct url" do
-    assert "/" = FilePath.source_to_url({}, "./content/index.md")
+    assert "/" = FilePath.source_to_url({}, "content/index.md")
     assert "/" = FilePath.source_to_url({}, "/index.md")
 
-    assert "/posts/test.html" = FilePath.source_to_url({}, "./content/posts/test.md")
+    assert "/posts/test.html" = FilePath.source_to_url({}, "content/posts/test.md")
     assert "/posts/test.html" = FilePath.source_to_url({}, "/posts/test.md")
   end
 end

--- a/test/fryse/template_helpers_test.exs
+++ b/test/fryse/template_helpers_test.exs
@@ -111,7 +111,7 @@ defmodule Fryse.TemplateHelpersTest do
 
   test "link_to/2 returns the link to the given Page, File or source file path", %{fryse: fryse} do
     file = %FryseFile{
-      path: "./content/posts/your-new-fryse-blog.md"
+      path: "content/posts/your-new-fryse-blog.md"
     }
 
     page = %Page{
@@ -123,6 +123,6 @@ defmodule Fryse.TemplateHelpersTest do
     assert "/posts/your-new-fryse-blog.html" = TemplateHelpers.link_to(page, file)
 
     assert "/posts/your-new-fryse-blog.html" =
-             TemplateHelpers.link_to(page, "./content/posts/your-new-fryse-blog.md")
+             TemplateHelpers.link_to(page, "content/posts/your-new-fryse-blog.md")
   end
 end


### PR DESCRIPTION
The path handling hat to be refactored. The old method wildly used relative paths. Source and destination locations were assumed from the current `pwd`.

Now the Fryse struct holds the source and destination paths which are absolute. The destination path defaults to `source_path <> "/_site"` but can easily be changed now. The parsed content structs hold paths which are relative to the source path which makes it easy to work with.