### PR TITLE
Add cli functionality to list commands and their docs

### DIFF
--- a/lib/fryse/cli.ex
+++ b/lib/fryse/cli.ex
@@ -6,6 +6,7 @@ defmodule Fryse.CLI do
 
     case find_command(parsed) do
       {:error, :not_found} -> show_not_found_notice(parsed)
+      {:ok, :no_command} -> show_no_command_notice()
       {_, module} -> invoke_command(module, args)
     end
   end
@@ -14,22 +15,55 @@ defmodule Fryse.CLI do
     [
       {:new, Fryse.CLI.New},
       {:build, Fryse.CLI.Build},
-      {:serve, Fryse.CLI.Serve}
+      {:serve, Fryse.CLI.Serve},
+      {:help, Fryse.CLI.Help}
     ]
   end
 
-  defp find_command({_, [cmd | _], _}) do
+  def find_command({_, [], _}) do
+    {:ok, :no_command}
+  end
+  def find_command({_, [cmd | _], _}) do
     cmd = String.to_atom(cmd)
 
     commands()
     |> Enum.find({:error, :not_found}, fn {command, _} -> command == cmd end)
+  end
+  def find_command(cmd) do
+    find_command({[], [cmd], []})
   end
 
   defp invoke_command(module, args) do
     apply(module, :run, [args])
   end
 
+  defp show_no_command_notice() do
+    Mix.shell().info("Fryse #{Application.spec(:fryse, :vsn)} \n")
+
+    show_available_commands()
+  end
+
+  def show_available_commands() do
+    Mix.shell().info("Available commands:")
+
+    command_width = greatest_command_length() + 3
+    for {cmd, module} <- commands() do
+      command = Atom.to_string(cmd)
+      shortdoc = Mix.Task.shortdoc(module)
+      Mix.shell().info("fryse #{String.pad_trailing(command, command_width)} # #{shortdoc}")
+    end
+  end
+
   defp show_not_found_notice({_, [cmd | _], _}) do
-    Mix.shell().error("Command \"#{cmd}\" could not be found")
+    Mix.shell().error("The command \"#{cmd}\" could not be found \n")
+
+    show_available_commands()
+  end
+
+  defp greatest_command_length() do
+    commands()
+    |> Enum.map(fn {cmd, _} -> Atom.to_string(cmd) end)
+    |> Enum.map(&String.length/1)
+    |> Enum.max(fn -> 0 end)
   end
 end

--- a/lib/fryse/cli/build.ex
+++ b/lib/fryse/cli/build.ex
@@ -1,5 +1,14 @@
 defmodule Fryse.CLI.Build do
-  @moduledoc false
+  use Fryse.Command
+
+  @shortdoc "Builds static files"
+
+  @moduledoc """
+  Builds static files. It expects the Fryse project to
+  be in the folder in which the command is executed in.
+
+  The static files will be written to `_site`.
+  """
 
   def run(args) do
     {switches, _, _} = OptionParser.parse(args, switches: [debug: :boolean])

--- a/lib/fryse/cli/help.ex
+++ b/lib/fryse/cli/help.ex
@@ -1,0 +1,47 @@
+defmodule Fryse.CLI.Help do
+  use Fryse.Command
+
+  @shortdoc "Prints help information for commands"
+
+  @moduledoc """
+  Lists all commands or prints the documentation for a given command.
+
+  ## Arguments
+
+      fryse help            - prints all commands and their short descriptions
+      fryse help COMMAND    - prints full docs for the given command
+  """
+
+  def run(args) do
+    {_, args, _} = OptionParser.parse(args)
+
+    case args do
+      ["help"] -> show_commands()
+      ["help", command | _] -> show_help(command)
+    end
+  end
+
+  defp show_commands() do
+    Fryse.CLI.show_available_commands()
+  end
+
+  defp show_help(command) do
+    case Fryse.CLI.find_command(command) do
+      {:error, :not_found} ->
+        Mix.shell().error("The command \"#{command}\" could not be found")
+
+      {_, module} ->
+        opts = [width: width()]
+        doc = apply(module, :moduledoc, [])
+        IO.ANSI.Docs.print_heading("fryse #{command}", opts)
+        IO.ANSI.Docs.print(doc, opts)
+    end
+  end
+
+  defp width() do
+    case :io.columns() do
+      {:ok, width} -> min(width, 80)
+      {:error, _} -> 80
+    end
+  end
+end

--- a/lib/fryse/cli/new.ex
+++ b/lib/fryse/cli/new.ex
@@ -1,5 +1,17 @@
 defmodule Fryse.CLI.New do
-  @moduledoc false
+  use Fryse.Command
+
+  @shortdoc "Creates a new Fryse project"
+
+  @moduledoc """
+  Creates a new Fryse project.
+  It expects the name of the project as argument.
+
+      fryse new NAME
+
+  A project will be created in a new folder named after the project.
+  The project name will also be used to name script modules and for the example config.
+  """
 
   alias HTTPoison.Response
 

--- a/lib/fryse/cli/serve.ex
+++ b/lib/fryse/cli/serve.ex
@@ -1,4 +1,8 @@
 defmodule Fryse.CLI.Serve do
+  use Fryse.Command
+
+  @shortdoc "Serves static files"
+
   @moduledoc false
 
   def run(args) do

--- a/lib/fryse/command.ex
+++ b/lib/fryse/command.ex
@@ -1,0 +1,22 @@
+defmodule Fryse.Command do
+  @moduledoc false
+
+  defmacro __using__(_options) do
+    quote do
+      Module.register_attribute __MODULE__, :shortdoc, persist: true
+
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    moduledoc = Module.get_attribute(env.module, :moduledoc)
+
+    quote do
+      def moduledoc() do
+        {_, moduledoc} = unquote(moduledoc)
+        moduledoc
+      end
+    end
+  end
+end


### PR DESCRIPTION
This finally makes the CLI part much easier for the user.

`fryse` now lists all available commands and their short description.
`fryse help COMMAND` shows the full docs of a command