### PR TITLE
Define and implement how errors should be handled

### DIFF
--- a/lib/fryse/command.ex
+++ b/lib/fryse/command.ex
@@ -4,7 +4,7 @@ defmodule Fryse.Command do
   defmacro __using__(_options) do
     quote do
       Module.register_attribute __MODULE__, :shortdoc, persist: true
-
+      import unquote(__MODULE__), only: [stop: 0, stop: 1]
       @before_compile unquote(__MODULE__)
     end
   end
@@ -18,5 +18,10 @@ defmodule Fryse.Command do
         moduledoc
       end
     end
+  end
+
+  def stop(code \\ 0) do
+    #TODO: Wait until http://erlang.org/pipermail/erlang-bugs/2014-June/004450.html is resolved and change back to `System.stop()`
+    System.halt(code)
   end
 end

--- a/lib/fryse/error_bag.ex
+++ b/lib/fryse/error_bag.ex
@@ -1,0 +1,10 @@
+defmodule Fryse.ErrorBag do
+  @moduledoc false
+
+  defstruct context: nil, errors: []
+
+  @typep context :: nil | atom
+  @typep error :: struct | map | String.t
+
+  @type t :: %__MODULE__{context: context, errors: list(error)}
+end

--- a/lib/fryse/errors/invalid_script_module.ex
+++ b/lib/fryse/errors/invalid_script_module.ex
@@ -1,0 +1,18 @@
+defmodule Fryse.Errors.InvalidScriptModule do
+  @moduledoc false
+
+  defstruct type: nil, path: nil, line: nil, description: nil
+
+  @typep type :: :error | :warning
+  @typep path :: String.t
+  @typep line :: integer
+  @typep description :: description
+
+  @type t :: %__MODULE__{type: type, path: path, line: line, description: description}
+end
+
+defimpl String.Chars, for: Fryse.Errors.InvalidScriptModule do
+  def to_string(%{description: description}) do
+    description
+  end
+end

--- a/lib/fryse/errors/missing_required_file.ex
+++ b/lib/fryse/errors/missing_required_file.ex
@@ -1,0 +1,19 @@
+defmodule Fryse.Errors.MissingRequiredFile do
+  @moduledoc false
+
+  defstruct type: nil, path: nil
+
+  @typep type :: :file | :folder
+  @typep path :: String.t
+
+  @type t :: %__MODULE__{type: type, path: path}
+end
+
+defimpl String.Chars, for: Fryse.Errors.MissingRequiredFile do
+  def to_string(%{type: :file, path: path}) do
+    "File '#{path}'"
+  end
+  def to_string(%{type: :folder, path: path}) do
+    "Folder at '#{path}'"
+  end
+end

--- a/lib/fryse/script_loader.ex
+++ b/lib/fryse/script_loader.ex
@@ -1,6 +1,9 @@
 defmodule Fryse.ScriptLoader do
   @moduledoc false
 
+  alias Fryse.ErrorBag
+  alias Fryse.Errors.InvalidScriptModule
+
   def load_for(%Fryse{config: %{theme: theme}, source_path: source_path}) do
     project_scripts = project_scripts(source_path)
     theme_scripts = theme_scripts(source_path, theme)
@@ -9,7 +12,21 @@ defmodule Fryse.ScriptLoader do
 
     case Kernel.ParallelCompiler.compile(files) do
       {:ok, _, _} -> :ok
-      {:error, errors, warnings} -> {:error, errors, warnings}
+      {:error, errors, warnings} ->
+        errors = Enum.map(errors, fn {file, line, description} ->
+          %InvalidScriptModule{type: :error, path: file, line: line, description: description}
+        end)
+
+        warnings = Enum.map(warnings, fn {file, line, description} ->
+          %InvalidScriptModule{type: :warning, path: file, line: line, description: description}
+        end)
+
+        error_bag = %ErrorBag{
+          context: :compile,
+          errors: errors ++ warnings
+        }
+
+        {:error, error_bag}
     end
   end
 


### PR DESCRIPTION
Adds an `ErrorBag` struct and two additional error specific structs. This makes it easy to model error tuples with multiple errors. The parser and file loader were updated to return error tuples with an ErrorBag. The builder was left out for now since it already handles render errors gracefully and everything else is unlikely to fail.