### PR TITLE
Rename page.path to page.url

### DIFF
--- a/lib/fryse/builder.ex
+++ b/lib/fryse/builder.ex
@@ -74,9 +74,9 @@ defmodule Fryse.Builder do
 
   defp hydrate_pages(pages, %Fryse{} = fryse) do
     Enum.map(pages, fn page ->
-      path = FilePath.source_to_url(fryse.config, page.file.path)
+      url = FilePath.source_to_url(fryse.config, page.file.path)
       # Fryse struct won't get added here due to memory consumption
-      %Page{ page | path: path}
+      %Page{ page | url: url}
     end)
   end
 

--- a/lib/fryse/cli/build.ex
+++ b/lib/fryse/cli/build.ex
@@ -93,6 +93,12 @@ defmodule Fryse.CLI.Build do
     #TODO: no case clause matching: %UndefinedFunctionError{arity: 2, exports: nil, function: :author, module: FriseDefaultTheme, reason: nil}
     error_description =
       case error do
+        %KeyError{key: :path, term: %Fryse.Page{}} ->
+          "'@page.path' is deprecated, use '@page.url'"
+
+        %KeyError{key: key} ->
+          "Cannot access key '#{key}' (usage might be in layout file)"
+
         %{description: description, file: "nofile", line: line} ->
           "#{description} in #{source} on line #{line} (line counting starts below the frontmatter section)"
 

--- a/lib/fryse/page.ex
+++ b/lib/fryse/page.ex
@@ -3,5 +3,5 @@ defmodule Fryse.Page do
 
   defstruct fryse: nil,
             file: nil,
-            path: nil
+            url: nil
 end

--- a/lib/fryse/template_helpers.ex
+++ b/lib/fryse/template_helpers.ex
@@ -122,7 +122,7 @@ defmodule Fryse.TemplateHelpers do
   def is_active(%Page{} = page, path, when_active), do: is_active(page, path, when_active, false)
 
   def is_active(%Page{} = page, path, when_active, when_inactive) do
-    if page.path == FilePath.source_to_url(page.fryse.config, to_string(path)) do
+    if page.url == FilePath.source_to_url(page.fryse.config, to_string(path)) do
       when_active
     else
       when_inactive

--- a/test/fryse/template_helpers_test.exs
+++ b/test/fryse/template_helpers_test.exs
@@ -12,7 +12,7 @@ defmodule Fryse.TemplateHelpersTest do
     page = %Page{
       fryse: fryse,
       file: nil,
-      path: ""
+      url: ""
     }
 
     assert 2 = TemplateHelpers.files_from(page, "/posts") |> Enum.count()
@@ -91,7 +91,7 @@ defmodule Fryse.TemplateHelpersTest do
   test "is_active/2 returns if the given source file path is active", %{fryse: fryse} do
     page = %Page{
       fryse: fryse,
-      path: "/posts/your-new-fryse-blog.html"
+      url: "/posts/your-new-fryse-blog.html"
     }
 
     assert true == TemplateHelpers.is_active(page, "/posts/your-new-fryse-blog.md")
@@ -102,7 +102,7 @@ defmodule Fryse.TemplateHelpersTest do
   test "is_active/3 and is_active/4 return custom values for active and inactive", %{fryse: fryse} do
     page = %Page{
       fryse: fryse,
-      path: "/posts/your-new-fryse-blog.html"
+      url: "/posts/your-new-fryse-blog.html"
     }
 
     assert :active == TemplateHelpers.is_active(page, "/posts/your-new-fryse-blog.md", :active)


### PR DESCRIPTION
Having an `url` field instead of a `path` field on the `Page` struct seems more logical. The `File` struct still has a `path` field because it represents an actual file.