### PR TITLE
Config override

### DIFF
--- a/lib/fryse.ex
+++ b/lib/fryse.ex
@@ -5,7 +5,7 @@ defmodule Fryse do
   Full documentation will follow soon.
   """
 
-  alias Fryse.{Indexer, ScriptLoader, Builder}
+  alias Fryse.{Indexer, Config, ScriptLoader, Builder}
 
   defstruct config: nil,
             data: nil,
@@ -15,6 +15,13 @@ defmodule Fryse do
 
   def index(path) do
     Indexer.index(path)
+  end
+
+  def validate_config(%Fryse{config: config}) do
+    validate_config(config)
+  end
+  def validate_config(config) do
+    Config.validate(config)
   end
 
   def load_scripts(%Fryse{} = fryse) do

--- a/lib/fryse/cli/build.ex
+++ b/lib/fryse/cli/build.ex
@@ -2,6 +2,8 @@ defmodule Fryse.CLI.Build do
   use Fryse.Command
 
   alias Fryse.ErrorBag
+  alias Fryse.FileLoader
+  alias Fryse.Config
 
   @shortdoc "Builds static files"
 
@@ -9,18 +11,36 @@ defmodule Fryse.CLI.Build do
   Builds static files. It expects the Fryse project to
   be in the folder in which the command is executed in.
 
+      fryse build [--config-override PATH]
+
+  An `--config-override` or `-o` option can be given to override
+  the config with another config file. The values in the given
+  config file will override the values in the normal config.
+  This can be seen as a form of environment config.
+
   The static files will be written to `_site`.
   """
 
   @doc false
   def run(args) do
-    {switches, _, _} = OptionParser.parse(args, switches: [debug: :boolean])
+    {switches, _, _} = OptionParser.parse(
+      args,
+      switches: [
+        debug: :boolean,
+        config_override: :string
+      ],
+      aliases: [
+        o: :config_override
+      ]
+    )
     debug = Keyword.get(switches, :debug, false)
+    config_override = Keyword.get(switches, :config_override, false)
 
-    with {:indexing, {:ok, %Fryse{} = fryse}} <- {:indexing, Fryse.index(".")},
-         {:config_validation, :ok}            <- {:config_validation, Fryse.validate_config(fryse)},
-         {:script_loading, :ok}               <- {:script_loading, Fryse.load_scripts(fryse)},
-         {:building, {:ok, results}}          <- {:building, Fryse.build(fryse)} do
+    with {:indexing, {:ok, %Fryse{} = fryse}}         <- {:indexing, Fryse.index(".")},
+         {:config_override, {:ok, %Fryse{} = fryse}}  <- {:config_override, apply_override_config(fryse, config_override)},
+         {:config_validation, :ok}                    <- {:config_validation, Fryse.validate_config(fryse)},
+         {:script_loading, :ok}                       <- {:script_loading, Fryse.load_scripts(fryse)},
+         {:building, {:ok, results}}                  <- {:building, Fryse.build(fryse)} do
       if debug do
         IO.inspect(fryse)
         IO.inspect(results)
@@ -34,6 +54,19 @@ defmodule Fryse.CLI.Build do
       {task, reason} ->
         show_task_errors(task, reason)
         stop(1)
+    end
+  end
+
+  defp apply_override_config(%Fryse{} = fryse, false), do: {:ok, fryse}
+  defp apply_override_config(%Fryse{} = fryse, path) do
+    absolute_path = Path.expand(path)
+
+    with {:ok, config} <- FileLoader.load_file(absolute_path),
+         overridden_config <- Config.override(fryse.config, config) do
+
+      new_fryse = %Fryse{fryse | config: overridden_config}
+
+      {:ok, new_fryse}
     end
   end
 

--- a/lib/fryse/cli/build.ex
+++ b/lib/fryse/cli/build.ex
@@ -18,6 +18,7 @@ defmodule Fryse.CLI.Build do
     debug = Keyword.get(switches, :debug, false)
 
     with {:indexing, {:ok, %Fryse{} = fryse}} <- {:indexing, Fryse.index(".")},
+         {:config_validation, :ok}            <- {:config_validation, Fryse.validate_config(fryse)},
          {:script_loading, :ok}               <- {:script_loading, Fryse.load_scripts(fryse)},
          {:building, {:ok, results}}          <- {:building, Fryse.build(fryse)} do
       if debug do
@@ -42,7 +43,7 @@ defmodule Fryse.CLI.Build do
       IO.puts "- #{error}"
     end
   end
-  defp show_task_errors(:indexing, %ErrorBag{context: :config_validation, errors: errors}) do
+  defp show_task_errors(:config_validation, %ErrorBag{context: :validate, errors: errors}) do
     IO.puts(red("Config validation failed:"))
     for error <- errors do
       IO.puts "- #{error}"

--- a/lib/fryse/config.ex
+++ b/lib/fryse/config.ex
@@ -70,6 +70,12 @@ defmodule Fryse.Config do
     end)
   end
 
+  def override(config, config2) do
+    Map.merge(config, config2, fn _k, _v1, v2 ->
+      v2
+    end)
+  end
+
   defp only_errors(:ok), do: false
   defp only_errors(_), do: true
 

--- a/lib/fryse/config.ex
+++ b/lib/fryse/config.ex
@@ -1,6 +1,7 @@
 defmodule Fryse.Config do
   @moduledoc false
 
+  alias Fryse.ErrorBag
   alias Fryse.Errors.MissingConfigValue
   alias Fryse.Errors.InvalidConfigValue
 
@@ -22,7 +23,13 @@ defmodule Fryse.Config do
 
     case errors do
       [] -> :ok
-      errors -> {:error, errors}
+      errors ->
+        error_bag = %ErrorBag{
+          context: :validate,
+          errors: errors
+        }
+
+        {:error, error_bag}
     end
   end
 

--- a/lib/fryse/indexer.ex
+++ b/lib/fryse/indexer.ex
@@ -58,17 +58,9 @@ defmodule Fryse.Indexer do
     config_path = Path.join(path, "config.yml")
 
     with {:ok, config} <- FileLoader.load_file(config_path),
-         merged_config <- Config.merge(config, Config.default_config()),
-         {:validation, :ok} <- {:validation, Config.validate(merged_config)} do
+         merged_config <- Config.merge(config, Config.default_config()) do
 
       {:ok, merged_config}
-    else
-      {:validation, {:error, errors}} ->
-        {:error, %ErrorBag{
-          context: :config_validation,
-          errors: errors
-        }}
-      value -> value
     end
   end
 

--- a/test/fryse/config_test.exs
+++ b/test/fryse/config_test.exs
@@ -17,6 +17,19 @@ defmodule Fryse.ConfigTest do
     end
   end
 
+  describe "override/2" do
+    test "original and override values are merged" do
+      original = %{foo: "one", bar: "two"}
+      override = %{baz: "three"}
+      assert %{foo: "one", bar: "two", baz: "three"} = Config.override(original, override)
+    end
+    test "original values are overridden by override values" do
+      original = %{foo: "one", bar: "two"}
+      override = %{baz: "three", foo: "four"}
+      assert %{foo: "four", bar: "two", baz: "three"} = Config.override(original, override)
+    end
+  end
+
   describe "validate :theme key" do
     test "the key must be not nil" do
       assert %MissingConfigValue{key: :theme} = Config.validate_key(:theme, nil)


### PR DESCRIPTION
Adds the `--config-override` or `-o` option to the `fryse build` command.

This way, one can specify an additional config file which will override the normal config.

It can be seen as a form of environment config where one build needs to have a slightly different config than another build.

The main use case for which this was added is to create a build for github pages. Project pages run under a subpath which breaks the generated links. Now one can create a `config.gh-pages.yml` (or any other named file) which will set a path prefix (not implemented yet). To create a build specially for github pages, one then needs to execute `fryse build -o config.gh-pages.yml` and all paths should be generated properly.